### PR TITLE
Suggestions for performance improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	ipv4 := addr.To4()
+	if ipv4 == nil {
+		log.Fatal("built for IPv4 only")
+	}
+
 	var ips []string
 	for ip := addr.Mask(network.Mask); network.Contains(ip); inc(ip) {
 		ips = append(ips, ip.String())

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ func main() {
 	log.SetFlags(0)
 
 	var ipRange string
-	var err error
 
 	if len(os.Args) > 1 {
 		// The range was passed in as an argument
@@ -33,12 +32,10 @@ func main() {
 	} else {
 		// Read from standard input
 		reader := bufio.NewReader(os.Stdin)
-		ipRange, err = reader.ReadString('\n')
-		if err != nil {
-			log.Fatal(err)
-		}
-		ipRange = strings.TrimSpace(ipRange)
+		ipRange, _ = reader.ReadString('\n')
 	}
+
+	ipRange = strings.TrimSpace(ipRange)
 
 	spl := strings.Split(ipRange, "/")
 	if len(spl) < 2 {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 )
@@ -36,19 +35,6 @@ func main() {
 	}
 
 	ipRange = strings.TrimSpace(ipRange)
-
-	spl := strings.Split(ipRange, "/")
-	if len(spl) < 2 {
-		log.Fatal("bad cidr")
-	}
-	r, err := strconv.Atoi(spl[1])
-	if err != nil {
-		log.Fatal(err)
-	}
-	if r < 8 {
-		log.Fatal("range cannot be smaller than 8")
-	}
-
 	addr, network, err := net.ParseCIDR(ipRange)
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -10,15 +10,6 @@ import (
 	"text/tabwriter"
 )
 
-func inc(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
-			break
-		}
-	}
-}
-
 func main() {
 	log.SetPrefix("")
 	log.SetFlags(0)

--- a/main.go
+++ b/main.go
@@ -45,16 +45,23 @@ func main() {
 		log.Fatal("built for IPv4 only")
 	}
 
-	var ips []string
-	for ip := addr.Mask(network.Mask); network.Contains(ip); inc(ip) {
-		ips = append(ips, ip.String())
+	subnetMask := network.Mask
+	firstIp := make([]byte, len(ipv4))
+	lastIp := make([]byte, len(ipv4))
+	numIPs := 0
+
+	for i := range ipv4 {
+		firstIp[i] = ipv4[i] & subnetMask[i]
+		lastIp[i] = ipv4[i] | (subnetMask[i] ^ 0xff)
+		numIPs <<= 8
+		numIPs += int(subnetMask[i] ^ 0xff)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "CIDR Range:\t%s\n", network)
 	fmt.Fprintf(w, "Netmask:\t%d.%d.%d.%d\n", network.Mask[0], network.Mask[1], network.Mask[2], network.Mask[3])
-	fmt.Fprintf(w, "First IP:\t%s\n", ips[0])
-	fmt.Fprintf(w, "Last IP:\t%s\n", ips[len(ips)-1])
-	fmt.Fprintf(w, "Addresses:\t%d\n", len(ips))
+	fmt.Fprintf(w, "First IP:\t%s\n", net.IP(firstIp))
+	fmt.Fprintf(w, "Last IP:\t%s\n", net.IP(lastIp))
+	fmt.Fprintf(w, "Addresses:\t%d\n", numIPs+1)
 	w.Flush()
 }


### PR DESCRIPTION
Rather than incrementally testing each IP address in the network, you can directly calculate the answers in constant time. It results in a noticeable performance gain on especially large subnets like `/8`.

### Original
```
time ./ipcalc_original 10.0.0.0/8
CIDR Range: 10.0.0.0/8
Netmask:    255.0.0.0
First IP:   10.0.0.0
Last IP:    10.255.255.255
Addresses:  16777216

________________________________________________________
Executed in    2.09 secs    fish           external
   usr time    2.95 secs  123.00 micros    2.95 secs
   sys time    0.47 secs  769.00 micros    0.47 secs
```

### Suggested
```
time ./ipcalc_suggestions 10.0.0.0/8
CIDR Range: 10.0.0.0/8
Netmask:    255.0.0.0
First IP:   10.0.0.0
Last IP:    10.255.255.255
Addresses:  16777216

________________________________________________________
Executed in    6.49 millis    fish           external
   usr time    2.15 millis  112.00 micros    2.04 millis
   sys time    3.18 millis  667.00 micros    2.51 millis
```